### PR TITLE
Edit condition-cpt.php: Adds taxomony archives into validation for cu…

### DIFF
--- a/src/condition-cpt.php
+++ b/src/condition-cpt.php
@@ -100,7 +100,7 @@ class Smk_Sidebar_Generator_Condition_Cpt extends Smk_Sidebar_Generator_Conditio
         // Custom Post Type
         else{
             if( empty($second_selection) ){
-                if( is_singular( $first_selection ) || is_post_type_archive( $first_selection )  ){
+                if (is_singular($first_selection) || is_post_type_archive($first_selection) || is_tax(get_object_taxonomies($first_selection))) {
                     $can = true;
                 }
             }
@@ -108,7 +108,8 @@ class Smk_Sidebar_Generator_Condition_Cpt extends Smk_Sidebar_Generator_Conditio
                 in_array('all_archives_single', (array) $second_selection) &&
                 (
                     is_singular( $first_selection ) ||
-                    is_post_type_archive( $first_selection )
+                    is_post_type_archive( $first_selection ) ||
+                    is_tax(get_object_taxonomies($first_selection))
                 )
             ){
                 $can = true;


### PR DESCRIPTION
…stom post types

Previously, taxonomy archives of custom post types would not be detected when checking for `is_singular( in post type )` OR `is_post_type_archive( post type )`. I added the taxonomy check as well. As from the `is_tax()` function description from wordpress: `Determines whether the query is for an existing custom taxonomy archive page.`. By passing `get_object_taxonomies( post type )` to this method, it will check if the current archive is a taxonomy archive of any taxonomy of the given post type.

Should solve this issue: https://github.com/awps/smk-sidebar-generator/issues/35